### PR TITLE
Compare Native-vs-Native instead of Semantic-vs-Native

### DIFF
--- a/main.go
+++ b/main.go
@@ -128,7 +128,7 @@ func (c *Client) Consequentially(path, language string, times int) time.Duration
 	st := time.Now()
 
 	for i := 0; i < times; i++ {
-		r, err := c.client.NewParseRequestV2().Language(language).Content(content).Do()
+		r, err := c.client.NewParseRequestV2().Language(language).Mode(bblfsh.Native).Content(content).Do()
 
 		if len(r.Errors) > 0 {
 			panic(r.Errors)
@@ -153,7 +153,7 @@ func (c *Client) Parallel(path, language string, times, parallel int) time.Durat
 		wg.Add(1)
 		go func() {
 			for i := 0; i < times; i++ {
-				_, err := c.client.NewParseRequestV2().Language(language).Content(content).Do()
+				_, err := c.client.NewParseRequestV2().Language(language).Mode(bblfsh.Native).Content(content).Do()
 				if err != nil {
 					panic(err)
 				}


### PR DESCRIPTION
Currently, the benchmark runs the simplest possible native driver implementation and compares them to Babelfish running the full `Semantic` pipeline.

The fair comparison (of Babelfish overhead) will be to compare the `Native` parsing mode instead.

Here is the difference:

**Old:**
```
  language         fixture         bblfshd          driver          native           naive   naive-on-host
    python        small.py     42.620714ms     42.480507ms     56.216956ms         3.309ms             N/A
    python       medium.py    1.059333278s    1.154197299s    613.124986ms        82.772ms             N/A
    python        large.py    1.699238715s    1.845408743s    921.336252ms       134.222ms             N/A
      java      small.java     70.811603ms     43.072942ms     98.954753ms           368ms             N/A
      java     medium.java    451.102579ms    450.617656ms    209.986308ms           475ms             N/A
      java      large.java    1.215768862s    1.214031231s     337.83138ms           648ms             N/A
javascript        small.js     39.903627ms     32.405596ms     45.814808ms             N/A             N/A
javascript       medium.js    493.425669ms    459.422298ms    112.461368ms             N/A             N/A
javascript        large.js    3.688360473s     3.61853464s    316.902493ms             N/A             N/A
```
(you clearly see the significant "overhead" on native-driver comparison)

**New:**
```
  language         fixture         bblfshd          driver          native           naive   naive-on-host
    python        small.py     25.691442ms     24.672572ms     66.891088ms         4.556ms             N/A
    python       medium.py    560.361963ms    641.348453ms    623.827814ms        78.174ms             N/A
    python        large.py    851.685332ms    993.695721ms    929.113458ms       162.176ms             N/A
      java      small.java     29.831958ms     27.715017ms     92.131892ms           350ms             N/A
      java     medium.java    215.861703ms    283.977235ms    233.332771ms           463ms             N/A
      java      large.java    529.344821ms    543.577294ms    413.990141ms           619ms             N/A
javascript        small.js      13.77196ms     15.886834ms      50.89281ms             N/A             N/A
javascript       medium.js    149.167435ms    134.519043ms    120.307381ms             N/A             N/A
javascript        large.js    974.252204ms    1.044514084s    339.587874ms             N/A             N/A
```

But, you should probably close this PR, depending on the purpose of this benchmark.

If the aim is to show the overhead that Babelfish has, then it can be merged.

But if it's a general-purpose benchmark, then it makes sense to close this PR and add two tables to the benchmark: one that compares the overhead, and the second that benchmarks `Semantic` mode for different drivers and file sizes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/smacker/bblfsh-benchmark/2)
<!-- Reviewable:end -->
