### PR TITLE
Use the new client (v3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Benchmarks for bblfsh
 
-_Note:_ According to the benchmarks drivers v2 are slower about two times than v1 (using v1 protocol in both cases).
+_Note:_ According to the benchmarks drivers v2 are slower about two times than v1.
 
 ### how to run
 

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 	"sync"
 	"time"
 
-	bblfsh "gopkg.in/bblfsh/client-go.v2"
+	bblfsh "gopkg.in/bblfsh/client-go.v3"
 )
 
 var path = flag.String("path", "", "path to file")
@@ -128,13 +128,10 @@ func (c *Client) Consequentially(path, language string, times int) time.Duration
 	st := time.Now()
 
 	for i := 0; i < times; i++ {
-		r, err := c.client.NewParseRequestV2().Language(language).Mode(bblfsh.Native).Content(content).Do()
+		_, _, err := c.client.NewParseRequest().Language(language).Mode(bblfsh.Native).Content(content).UAST()
 
 		if err != nil {
 			panic(err)
-		}
-		if len(r.Errors) > 0 {
-			panic(r.Errors)
 		}
 	}
 
@@ -153,7 +150,7 @@ func (c *Client) Parallel(path, language string, times, parallel int) time.Durat
 		wg.Add(1)
 		go func() {
 			for i := 0; i < times; i++ {
-				_, err := c.client.NewParseRequestV2().Language(language).Mode(bblfsh.Native).Content(content).Do()
+				_, _, err := c.client.NewParseRequest().Language(language).Mode(bblfsh.Native).Content(content).UAST()
 				if err != nil {
 					panic(err)
 				}


### PR DESCRIPTION
Switch to using the new v3 client.

It makes nearly no difference for the benchmark because v2 client uses v2 protocol under the hood anyway, even though it emulates v1 client API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/smacker/bblfsh-benchmark/3)
<!-- Reviewable:end -->
